### PR TITLE
Add equality helpers for CamareiraResumo

### DIFF
--- a/src/main/java/com/motel/app/model/CamareiraResumo.java
+++ b/src/main/java/com/motel/app/model/CamareiraResumo.java
@@ -1,5 +1,7 @@
 package com.motel.app.model;
 
+import java.util.Objects;
+
 public class CamareiraResumo {
     private String nome;
     private int tipoA;
@@ -29,4 +31,38 @@ public class CamareiraResumo {
     public int getTipoE() { return tipoE; }
     public int getQuantidade() { return quantidade; }
     public double getTempoMedio() { return tempoMedio; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof CamareiraResumo)) return false;
+        CamareiraResumo that = (CamareiraResumo) o;
+        return tipoA == that.tipoA &&
+                tipoB == that.tipoB &&
+                tipoC == that.tipoC &&
+                tipoD == that.tipoD &&
+                tipoE == that.tipoE &&
+                quantidade == that.quantidade &&
+                Double.compare(that.tempoMedio, tempoMedio) == 0 &&
+                Objects.equals(nome, that.nome);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nome, tipoA, tipoB, tipoC, tipoD, tipoE, quantidade, tempoMedio);
+    }
+
+    @Override
+    public String toString() {
+        return "CamareiraResumo{" +
+                "nome='" + nome + '\'' +
+                ", tipoA=" + tipoA +
+                ", tipoB=" + tipoB +
+                ", tipoC=" + tipoC +
+                ", tipoD=" + tipoD +
+                ", tipoE=" + tipoE +
+                ", quantidade=" + quantidade +
+                ", tempoMedio=" + tempoMedio +
+                '}';
+    }
 }

--- a/src/test/java/com/motel/app/model/CamareiraResumoTest.java
+++ b/src/test/java/com/motel/app/model/CamareiraResumoTest.java
@@ -1,0 +1,20 @@
+package com.motel.app.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CamareiraResumoTest {
+    @Test
+    public void testEqualsAndHashCode() {
+        CamareiraResumo a = new CamareiraResumo("Maria",1,2,3,4,5,6,7.5);
+        CamareiraResumo b = new CamareiraResumo("Maria",1,2,3,4,5,6,7.5);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testToStringContainsName() {
+        CamareiraResumo a = new CamareiraResumo("Ana",0,0,0,0,0,0,0.0);
+        assertTrue(a.toString().contains("Ana"));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `equals`, `hashCode` and `toString` in `CamareiraResumo` model
- Add basic JUnit tests for the model

## Testing
- `mvn -q test` *(fails: Plugin org.codehaus.mojo:exec-maven-plugin:3.1.0 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689cfbd3e534832da652f148912e163c