### PR TITLE
Add Despertador screen and controller

### DIFF
--- a/src/main/java/com/motel/app/controller/DespertadorController.java
+++ b/src/main/java/com/motel/app/controller/DespertadorController.java
@@ -1,0 +1,42 @@
+package com.motel.app.controller;
+
+import javafx.animation.PauseTransition;
+import javafx.fxml.FXML;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.util.Duration;
+
+public class DespertadorController {
+
+    @FXML
+    private TextField txtSegundos;
+
+    @FXML
+    private Label lblStatus;
+
+    private PauseTransition pause;
+
+    @FXML
+    private void iniciarAlarme() {
+        if (pause != null) {
+            pause.stop();
+        }
+        try {
+            int segundos = Integer.parseInt(txtSegundos.getText());
+            pause = new PauseTransition(Duration.seconds(segundos));
+            pause.setOnFinished(e -> {
+                lblStatus.setText("Alarme disparado!");
+                Alert alert = new Alert(Alert.AlertType.INFORMATION);
+                alert.setTitle("Alarme");
+                alert.setHeaderText(null);
+                alert.setContentText("O alarme disparou!");
+                alert.showAndWait();
+            });
+            pause.play();
+            lblStatus.setText("Alarme definido para " + segundos + " segundos.");
+        } catch (NumberFormatException e) {
+            lblStatus.setText("Informe um número válido.");
+        }
+    }
+}

--- a/src/main/resources/com/motel/app/despertador.fxml
+++ b/src/main/resources/com/motel/app/despertador.fxml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.geometry.*?>
+
+<BorderPane xmlns="http://javafx.com/javafx/17.0.2-ea"
+            xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="com.motel.app.controller.DespertadorController"
+            style="-fx-background-color: linear-gradient(to bottom, #f8f9fa, #e9ecef);">
+    <center>
+        <VBox alignment="CENTER" spacing="25" prefHeight="500" prefWidth="600"
+              style="-fx-background-radius: 12; -fx-border-radius: 12; -fx-padding: 30;">
+            <!-- LOGO -->
+            <ImageView fitHeight="150" fitWidth="300" preserveRatio="true">
+                <image>
+                    <Image url="@/img/logo.png"/>
+                </image>
+            </ImageView>
+
+            <!-- TÍTULO -->
+            <Label text="Despertador"
+                   style="-fx-font-size: 28px; -fx-font-weight: bold; -fx-text-fill: #dc3545;" />
+
+            <!-- Tempo -->
+            <HBox alignment="CENTER" spacing="20">
+                <Label text="Tempo (segundos):"
+                       style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #495057;" />
+                <TextField fx:id="txtSegundos"
+                           prefWidth="200"
+                           style="-fx-font-size: 16px; -fx-font-weight: bold;" />
+            </HBox>
+
+            <!-- Botão -->
+            <Button text="Iniciar" onAction="#iniciarAlarme"
+                    style="-fx-font-size: 16px; -fx-font-weight: bold;"/>
+
+            <!-- Status -->
+            <Label fx:id="lblStatus"
+                   style="-fx-font-size: 14px; -fx-text-fill: #495057;" />
+        </VBox>
+    </center>
+</BorderPane>


### PR DESCRIPTION
## Summary
- Implemented a new alarm clock screen (`despertador.fxml`) with basic UI for setting an alarm in seconds
- Added `DespertadorController` to handle scheduling and displaying alarm notifications

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cfd954d8c832dbc40f2e5c25b6800