### PR TITLE
Add room number and wake-up time to alarm screen

### DIFF
--- a/src/main/java/com/motel/app/controller/DespertadorController.java
+++ b/src/main/java/com/motel/app/controller/DespertadorController.java
@@ -6,11 +6,16 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.util.Duration;
+import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 
 public class DespertadorController {
 
     @FXML
-    private TextField txtSegundos;
+    private TextField txtNumeroQuarto;
+
+    @FXML
+    private TextField txtHorario;
 
     @FXML
     private Label lblStatus;
@@ -23,20 +28,25 @@ public class DespertadorController {
             pause.stop();
         }
         try {
-            int segundos = Integer.parseInt(txtSegundos.getText());
-            pause = new PauseTransition(Duration.seconds(segundos));
+            String numeroQuarto = txtNumeroQuarto.getText();
+            LocalTime horario = LocalTime.parse(txtHorario.getText());
+            long delay = java.time.Duration.between(LocalTime.now(), horario).getSeconds();
+            if (delay < 0) {
+                delay += 24 * 60 * 60;
+            }
+            pause = new PauseTransition(Duration.seconds(delay));
             pause.setOnFinished(e -> {
-                lblStatus.setText("Alarme disparado!");
+                lblStatus.setText("Alarme disparado para o quarto " + numeroQuarto + "!");
                 Alert alert = new Alert(Alert.AlertType.INFORMATION);
                 alert.setTitle("Alarme");
                 alert.setHeaderText(null);
-                alert.setContentText("O alarme disparou!");
+                alert.setContentText("Alarme para o quarto " + numeroQuarto + " às " + horario + "!");
                 alert.showAndWait();
             });
             pause.play();
-            lblStatus.setText("Alarme definido para " + segundos + " segundos.");
-        } catch (NumberFormatException e) {
-            lblStatus.setText("Informe um número válido.");
+            lblStatus.setText("Alarme do quarto " + numeroQuarto + " definido para " + horario + ".");
+        } catch (DateTimeParseException e) {
+            lblStatus.setText("Informe um horário válido (HH:mm).");
         }
     }
 }

--- a/src/main/resources/com/motel/app/despertador.fxml
+++ b/src/main/resources/com/motel/app/despertador.fxml
@@ -23,11 +23,20 @@
             <Label text="Despertador"
                    style="-fx-font-size: 28px; -fx-font-weight: bold; -fx-text-fill: #dc3545;" />
 
-            <!-- Tempo -->
+            <!-- Número do Quarto -->
             <HBox alignment="CENTER" spacing="20">
-                <Label text="Tempo (segundos):"
+                <Label text="Número do quarto:"
                        style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #495057;" />
-                <TextField fx:id="txtSegundos"
+                <TextField fx:id="txtNumeroQuarto"
+                           prefWidth="200"
+                           style="-fx-font-size: 16px; -fx-font-weight: bold;" />
+            </HBox>
+
+            <!-- Horário -->
+            <HBox alignment="CENTER" spacing="20">
+                <Label text="Horário (HH:mm):"
+                       style="-fx-font-size: 16px; -fx-font-weight: bold; -fx-text-fill: #495057;" />
+                <TextField fx:id="txtHorario"
                            prefWidth="200"
                            style="-fx-font-size: 16px; -fx-font-weight: bold;" />
             </HBox>


### PR DESCRIPTION
## Summary
- Allow specifying room number and wake-up time for alarms
- Update alarm screen to include room number and requested time fields

## Testing
- `mvn -q -e test` *(fails: Plugin org.codehaus.mojo:exec-maven-plugin:3.1.0 or one of its dependencies could not be resolved: ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d3613fb3c832d99d02e4a36158cea